### PR TITLE
Create ipset-blacklist.service

### DIFF
--- a/ipset-blacklist.service
+++ b/ipset-blacklist.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Enable IP Blacklist firewall blocking on System Startup
+After=network.target lxc.service
+Documentation=man:ipset man:iptables
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/etc/ipset-blacklist
+ExecStartPre=/sbin/ipset restore -f /etc/ipset-blacklist/ip-blacklist.restore
+ExecStart=/sbin/iptables -I INPUT 1 -m set --match-set blacklist src -j DROP
+ExecStop=/sbin/iptables -D INPUT 1 -m set --match-set blacklist src
+ExecStopPost=/sbin/ipset destroy blacklist
+Delegate=yes
+StandardOutput=syslog
+StandardError=syslog
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hello, this is a simple systemd service configuration file to automatically activate the blacklist at system reboot.
It can be also used to start and stop the blacklist on demand with the commands:
systemctl start ipset-blacklist  and systemctl stop ipset-blacklist

All you need to do to activate the service is to put this file on your /etc/systemd/system directory and run the command: systemctl enable ipset-blacklist.service

Best Reguards.